### PR TITLE
Implementing suggested changes

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -2,8 +2,6 @@
 /**
  * IPA Validator class
  *
- * PHP version 7
- *
  * @package   IPA Validator
  * @author    TheresNoTime <sam@theresnotime.co.uk>
  * @copyright 2022 TheresNoTime
@@ -61,7 +59,6 @@ class Validator {
 	 * @param bool $strip Remove delimiters
 	 * @param bool $normalize Normalize IPA
 	 * @param bool $google Normalize IPA for Google TTS
-	 * @return void
 	 */
 	public function __construct( $ipa, $strip = true, $normalize = false, $google = false ) {
 		$this->originalIPA = strval( $ipa );
@@ -168,6 +165,6 @@ class Validator {
 			throw new Exception( 'Google normalization being enabled also requires normalization to also be enabled' );
 		}
 
-		return preg_match( $this->ipaRegex, $this->normalizedIPA );
+		return boolval( preg_match( $this->ipaRegex, $this->normalizedIPA ) );
 	}
 }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -94,6 +94,17 @@ class Validator {
 			$this->stripIPA();
 		}
 
+		// Common normalizations
+		/** @var string[] */
+		$charmap = [
+			[ "'", 'ˈ' ],
+			[ ':', 'ː' ],
+			[ ',', 'ˌ' ],
+		];
+		foreach ( $charmap as $char ) {
+			$this->normalizedIPA = str_replace( $char[0], $char[1], $this->normalizedIPA );
+		}
+
 		/*
 		 * I'm going to guess Google's normalization is weird
 		 * and different from what anyone else will want.
@@ -103,9 +114,6 @@ class Validator {
 			$charmap = [
 				[ '(', '' ],
 				[ ')', '' ],
-				[ "'", 'ˈ' ],
-				[ ':', 'ː' ],
-				[ ',', 'ˌ' ],
 				// 207F
 				[ 'ⁿ', 'n' ],
 				// 02B0
@@ -121,16 +129,6 @@ class Validator {
 				$this->normalizedIPA = str_replace( $char[0], $char[1], $this->normalizedIPA );
 			}
 			$this->removeDiacritics();
-		} else {
-			/** @var string[] */
-			$charmap = [
-				[ "'", 'ˈ' ],
-				[ ':', 'ː' ],
-				[ ',', 'ˌ' ],
-			];
-			foreach ( $charmap as $char ) {
-				$this->normalizedIPA = str_replace( $char[0], $char[1], $this->normalizedIPA );
-			}
 		}
 
 		return $this->normalizedIPA;

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1,13 +1,12 @@
 <?php
 declare( strict_types=1 );
-require_once __DIR__ . '/../vendor/autoload.php';
 use PHPUnit\Framework\TestCase;
 use TheresNoTime\IPAValidator\Validator;
 
+/**
+ * @covers TheresNoTime\IPAValidator\Validator
+ */
 final class ValidatorTest extends TestCase {
-	/**
-	 * @covers TheresNoTime\IPAValidator\Validator::__construct
-	 */
 	public function testCanBeCreatedFromIPA(): void {
 		$this->assertInstanceOf(
 			Validator::class,
@@ -15,16 +14,10 @@ final class ValidatorTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @covers TheresNoTime\IPAValidator\Validator::validate
-	 */
 	public function testValidation(): void {
 		$this->assertTrue( ( new Validator( '/pʰə̥ˈkj̊uːliɚ/', true, true, true ) )->valid );
 	}
 
-	/**
-	 * @covers TheresNoTime\IPAValidator\Validator::normalize
-	 */
 	public function testNormalization(): void {
 		$this->assertEquals(
 			'phəˈkjuːliɚ',
@@ -32,17 +25,11 @@ final class ValidatorTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @covers TheresNoTime\IPAValidator\Validator::validate
-	 */
 	public function testException(): void {
 		$this->expectException( Exception::class );
 		( new Validator( '/pʰə̥ˈkj̊uːliɚ/', false, false, true ) )->normalizedIPA;
 	}
 
-	/**
-	 * @covers TheresNoTime\IPAValidator\Validator::stripIPA
-	 */
 	public function testStripIPA(): void {
 		$this->assertEquals(
 			'pʰə̥ˈkj̊uːliɚ',
@@ -50,9 +37,6 @@ final class ValidatorTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @covers TheresNoTime\IPAValidator\Validator
-	 */
 	public function testOriginalIPA(): void {
 		$this->assertEquals(
 			'/pʰə̥ˈkj̊uːliɚ/',
@@ -60,9 +44,6 @@ final class ValidatorTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @covers TheresNoTime\IPAValidator\Validator
-	 */
 	public function testCorpus(): void {
 		$this->assertEquals(
 			'phəˈkjuːliɚ',


### PR DESCRIPTION
[Code review comments](https://github.com/theresnotime/php-ipa-validator/commit/f29bec1e96ce36cd1dee44678d43993846c1350a#comments) by @reedy, resolving:
-
- [???](https://github.com/theresnotime/php-ipa-validator/commit/f29bec1e96ce36cd1dee44678d43993846c1350a#r82644749)
- [Constructors return nothing... Not even void](https://github.com/theresnotime/php-ipa-validator/commit/f29bec1e96ce36cd1dee44678d43993846c1350a#r82644768)
- [Should this be casting the return result to a bool?](https://github.com/theresnotime/php-ipa-validator/commit/f29bec1e96ce36cd1dee44678d43993846c1350a#r82644921)
- [This shouldn't be necessary...](https://github.com/theresnotime/php-ipa-validator/commit/f29bec1e96ce36cd1dee44678d43993846c1350a#r82644940)
- [Just do `@covers TheresNoTime\IPAValidator\Validator` on the class](https://github.com/theresnotime/php-ipa-validator/commit/f29bec1e96ce36cd1dee44678d43993846c1350a#r82645086)

----
As for [the duplicated `foreach` loop](https://github.com/theresnotime/php-ipa-validator/commit/f29bec1e96ce36cd1dee44678d43993846c1350a#r82644826), [ac7deb0](https://github.com/theresnotime/php-ipa-validator/pull/3/commits/ac7deb004340bdb9150712d67d057fea62cb9da3) doesn't actually address the loop duplication, but at least it's split out into "common" normalizations and "specific" normalizations..